### PR TITLE
Process snatpolicy,  that selector having namespaces without labels

### DIFF
--- a/cmd/manager/utils/genutils.go
+++ b/cmd/manager/utils/genutils.go
@@ -55,6 +55,9 @@ func Remove(list []string, s string) []string {
 	return list
 }
 func MatchLabels(policylabels []aciv1.Label, reslabels map[string]string) bool {
+	if len(policylabels) == 0 {
+		return false
+	}
 	for _, label := range policylabels {
 		if _, ok := reslabels[label.Key]; ok {
 			if label.Value != reslabels[label.Key] {

--- a/cmd/manager/utils/k8sutils.go
+++ b/cmd/manager/utils/k8sutils.go
@@ -31,8 +31,8 @@ func GetPodNameFromReoncileRequest(requestName string) (string, string, string) 
 		UtilLog.Info("Length should be 4", "input string:", requestName, "lengthGot", len(temp))
 		return "", "", ""
 	}
-	snatPolicyName, resName, resType := temp[1], temp[2], temp[3]
-	return resName, snatPolicyName, resType
+	name, resName, resType := temp[1], temp[2], temp[3]
+	return resName, name, resType
 }
 
 // Get nodeinfo object matching given name of the node
@@ -231,16 +231,16 @@ func UpdateSnatPolicyStatus(NodeName string, snatPolicyName string, snatIp strin
 			if val.NodeName == NodeName {
 				nodePortRange[i] = nodePortRange[len(nodePortRange)-1]
 				nodePortRange = nodePortRange[:len(nodePortRange)-1]
+				foundSnatPolicy.Status.SnatPortsAllocated[snatIp] = nodePortRange
+				err = c.Status().Update(context.TODO(), &foundSnatPolicy)
+				if err != nil {
+					log.Error(err, "Policy Status Update Failed")
+					return reconcile.Result{}, err
+				}
 				break
 			}
 		}
-		log.Info("Updated Node Port Range for santIP ############# ", "snatIP", nodePortRange)
-		foundSnatPolicy.Status.SnatPortsAllocated[snatIp] = nodePortRange
-		err = c.Status().Update(context.TODO(), &foundSnatPolicy)
-		if err != nil {
-			log.Error(err, "Policy Status Update Failed")
-			return reconcile.Result{}, err
-		}
+
 	}
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Added support to Process the snatpolicy that selector having namespace and without labels.
This Policy will  apply  pods belongs to that namespace