### PR TITLE
Snatglobalinfo controller crash is fixed.

### DIFF
--- a/cmd/manager/utils/k8sutils.go
+++ b/cmd/manager/utils/k8sutils.go
@@ -213,6 +213,7 @@ func GetIPPortRangeForPod(NodeName string, snatpolicy *aciv1.SnatPolicy) (string
 				}
 			}
 		}
+		return v, expandedsnatports[0], false
 	}
 	return "", aciv1.PortRange{}, false
 }

--- a/pkg/controller/snatlocalinfo/mapper.go
+++ b/pkg/controller/snatlocalinfo/mapper.go
@@ -152,6 +152,10 @@ Loop:
 				}
 			}
 		} else {
+			// This case will come when namespace is specified in the policy
+			if item.Spec.Selector.Namespace != "" && item.Spec.Selector.Namespace != pod.ObjectMeta.Namespace {
+				continue
+			}
 
 			// Now need to match pod with correct snatPolicy item
 			// According to priority:


### PR DESCRIPTION
Problem:if more then 2 entries needs to be deleted in globalinfo while looping through
global info indexing the array got corrupted.
1.Added check if the policy is namespace level label match is executed when the Policy matches with Pod namespace
2. Added Finalizer will be cleared when the snatpolicy allocated entries are cleared.