### PR TITLE
Option to configure SNAT port range and portsPerNode using ConfigMap

### DIFF
--- a/pkg/controller/snatglobalinfo/snatglobalinfo_controller.go
+++ b/pkg/controller/snatglobalinfo/snatglobalinfo_controller.go
@@ -155,9 +155,11 @@ func (r *ReconcileSnatGlobalInfo) handleLocalinfoEvent(name string) (reconcile.R
 			}
 			var portrange aciv1.PortRange
 			if len(snatPolicy.Spec.SnatIp) == 0 {
-				portrange, _ = utils.GetPortRangeForServiceIP(instance.ObjectMeta.Name, &snatPolicy, snatip)
+				portrange, _ =
+					utils.GetPortRangeForServiceIP(r.client, instance.ObjectMeta.Name, &snatPolicy, snatip)
 			} else {
-				_, portrange, _ = utils.GetIPPortRangeForPod(instance.ObjectMeta.Name, &snatPolicy)
+				_, portrange, _ =
+					utils.GetIPPortRangeForPod(r.client, instance.ObjectMeta.Name, &snatPolicy)
 			}
 			if err != nil {
 				return reconcile.Result{}, err
@@ -230,9 +232,11 @@ func (r *ReconcileSnatGlobalInfo) handleLocalinfoEvent(name string) (reconcile.R
 				}
 				var portrange aciv1.PortRange
 				if len(snatPolicy.Spec.SnatIp) == 0 {
-					portrange, _ = utils.GetPortRangeForServiceIP(instance.ObjectMeta.Name, &snatPolicy, snatIp)
+					portrange, _ =
+						utils.GetPortRangeForServiceIP(r.client, instance.ObjectMeta.Name, &snatPolicy, snatIp)
 				} else {
-					_, portrange, _ = utils.GetIPPortRangeForPod(instance.ObjectMeta.Name, &snatPolicy)
+					_, portrange, _ =
+						utils.GetIPPortRangeForPod(r.client, instance.ObjectMeta.Name, &snatPolicy)
 				}
 				log.Info("Update Global CR for getting PortsRage  #####", "Portrage:", portrange)
 				portlist := []aciv1.PortRange{}


### PR DESCRIPTION
snat-operator now looks for a configMap in namespace "aci-containers-system" for a ConfigMap called "snat-operator-config" and parses it to get the required port range and ports to be allocated per node.
If there is no such ConfigMap present, or it has illegal integer values(i.e invalid int or start<5000 or end >65000 or portsPerNode > end-start)- it sets to default value of start 5000, end 65000 and portsPerNode 3000

ConfigMap looks like(provisioned as part of acc-provision):

apiVersion: v1
kind: ConfigMap
metadata:
  name: snat-operator-config
  namespace: aci-containers-system
  labels:
    aci-containers-config-version: "dummy"
    network-plugin: aci-containers
data:
    "start": "5001"
    "end": "65999"
    "portsPerNode": "2000"

If changes are made to this ConfigMap once a policy is applied, the updated numbers will be applied on the new policies and portRange assignments. The already existing ones stay the same. 