### PR TITLE
In particular sequence Policy delete is failing

### DIFF
--- a/cmd/manager/utils/k8sutils.go
+++ b/cmd/manager/utils/k8sutils.go
@@ -263,6 +263,7 @@ func GetPortRangeForServiceIP(NodeName string, snatpolicy *aciv1.SnatPolicy, sna
 				return expandedsnatports[i], false
 			}
 		}
+		return aciv1.PortRange{}, false
 	}
 	return expandedsnatports[0], false
 }


### PR DESCRIPTION
In particular sequence delete events of policy info is processed
deployment->service->snatpolicy. policy is not getting deleted because stale is present.
and also added changes to stop  processing the port allocation status updates.