### PR TITLE
Now added support if ip and ports exhausted mark the policy status as IpPortsExhausted

### DIFF
--- a/cmd/manager/utils/validate.go
+++ b/cmd/manager/utils/validate.go
@@ -33,7 +33,7 @@ func (v *Validator) ValidateSnatIP(cr *aciv1.SnatPolicy, c client.Client) {
 	if len(snatPolicyList.Items) > 1 {
 		cr_labels := cr.Spec.Selector.Labels
 		for _, item := range snatPolicyList.Items {
-			if item.Status.State == aciv1.Ready {
+			if item.Status.State != aciv1.Failed {
 				if cr.ObjectMeta.Name != item.ObjectMeta.Name {
 
 					// check if IP is repeated or invalid

--- a/pkg/apis/aci/v1/snatpolicy_types.go
+++ b/pkg/apis/aci/v1/snatpolicy_types.go
@@ -7,8 +7,9 @@ import (
 type PolicyState string
 
 const (
-	Ready  PolicyState = "Ready"
-	Failed PolicyState = "Failed"
+	Ready            PolicyState = "Ready"
+	Failed           PolicyState = "Failed"
+	IpPortsExhausted PolicyState = "IpPortsExhausted"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/controller/snatglobalinfo/snatglobalinfo_controller.go
+++ b/pkg/controller/snatglobalinfo/snatglobalinfo_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 
 	uuid "github.com/google/uuid"
@@ -237,6 +238,9 @@ func (r *ReconcileSnatGlobalInfo) handleLocalinfoEvent(name string) (reconcile.R
 				} else {
 					_, portrange, _ =
 						utils.GetIPPortRangeForPod(r.client, instance.ObjectMeta.Name, &snatPolicy)
+				}
+				if reflect.DeepEqual(portrange, aciv1.PortRange{}) {
+					continue
 				}
 				log.Info("Update Global CR for getting PortsRage  #####", "Portrage:", portrange)
 				portlist := []aciv1.PortRange{}

--- a/pkg/controller/snatlocalinfo/mapper.go
+++ b/pkg/controller/snatlocalinfo/mapper.go
@@ -154,7 +154,7 @@ func FilterPodsPerSnatPolicy(c client.Client, snatPolicyList *aciv1.SnatPolicyLi
 	var resType string
 Loop:
 	for _, item := range snatPolicyList.Items {
-		if item.GetDeletionTimestamp() != nil || item.Status.State != aciv1.Ready {
+		if item.GetDeletionTimestamp() != nil || item.Status.State == aciv1.Failed {
 			continue
 		}
 		if reflect.DeepEqual(item.Spec.Selector, aciv1.PodSelector{}) {

--- a/pkg/controller/snatpolicy/snatpolicy_controller.go
+++ b/pkg/controller/snatpolicy/snatpolicy_controller.go
@@ -112,10 +112,12 @@ func (r *ReconcileSnatPolicy) Reconcile(request reconcile.Request) (reconcile.Re
 		r.client.Status().Update(context.TODO(), instance)
 		return reconcile.Result{}, err
 	}
-	instance.Status.State = aciv1.Ready
-	err = r.client.Status().Update(context.TODO(), instance)
-	if err != nil {
-		return reconcile.Result{}, err
+	if instance.Status.State != aciv1.IpPortsExhausted {
+		instance.Status.State = aciv1.Ready
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 	reqLogger.Info("Policy successfully applied")
 


### PR DESCRIPTION
if IP+PORT RANGE exhausted mark the policy Status  IpPortsExhausted
and apply ip port for nodes which can be allocated. rest of the nodes will not be processed.
unless policy is modified by the user