### PR TITLE
Fallback policy is not working

### DIFF
--- a/pkg/controller/snatpolicy/snatpolicy_controller.go
+++ b/pkg/controller/snatpolicy/snatpolicy_controller.go
@@ -3,6 +3,7 @@ package snatpolicy
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/noironetworks/snat-operator/cmd/manager/utils"
@@ -149,6 +150,10 @@ func (r *ReconcileSnatPolicy) addFinalizer(m *aciv1.SnatPolicy) error {
 // Cleanup steps to be done when snatPolicy resource is getting deleted.
 func (r *ReconcileSnatPolicy) finalizeSnatPolicy(reqLogger logr.Logger, m *aciv1.SnatPolicy) error {
 	if len(m.Status.SnatPortsAllocated) != 0 {
+		//Finlizer will wait untill the snatlocalinfo controller deletes the policy related info.
+		// If it is still not deleted finalizer will check for snatpolicy refrence and deletes it after 2 secs.
+		// Error condtion it retries every 2 sec.
+		time.Sleep(time.Second * 2)
 		for _, portslist := range m.Status.SnatPortsAllocated {
 			for _, nodeinfo := range portslist {
 				localInfo, _ := utils.GetLocalInfoCR(r.client, nodeinfo.NodeName, os.Getenv("ACI_SNAT_NAMESPACE"))


### PR DESCRIPTION
When Snatpolicy delete  is triggered finalizer will be used to remove the stale entries.
but in the process of removing localinfo stale,  snatlocalinfo controller is also acting on the same data int that case update of CR is  throwing an error that is creating  issue. now introduced delay in finalizer logic to wait until all the updates are done from Snatlocalinfo controller if still present then finalizer deletes those stale.